### PR TITLE
Protect against invalid form input

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -613,7 +613,7 @@ class Jetpack_Subscriptions {
 			check_admin_referer( 'blogsub_subscribe_' . get_current_blog_id() );
 		}
 
-		if ( empty( $_REQUEST['email'] ) )
+		if ( empty( $_REQUEST['email'] ) || ! is_string( $_REQUEST['email'] ) )
 			return false;
 
 		$redirect_fragment = false;


### PR DESCRIPTION
Vulnerability scanners often attempt to inject invalid data into any form fields on a website, and when such a scanner does this to a site with the Jetpack Subscription widget on it, it's common to pass an array to the email field.

Ultimately, this causes a PHP Warning to be generated similar to the following:
> E_WARNING: wp-includes/formatting.php:3413 - strlen() expects parameter 1 to be string, array given

That's caused by passing an array to the `is_email()` function, which only accepts strings.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* An extra input check to validate that the argument is a valid string.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bugfix

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable Jetpack Subscriptions on a site, add the widget.
* Use the browser inspector to alter the `email` field name to be `name="email[]"`.
* Submit an email address, monitor the PHP logs, note the warning.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
